### PR TITLE
Add inventory tests

### DIFF
--- a/tests/Catlets.Tests.ps1
+++ b/tests/Catlets.Tests.ps1
@@ -83,7 +83,7 @@ capabilities:
       $vm = Get-VM -Name $catletName
 
       $vm.DynamicMemoryEnabled | Should -BeFalse
-      $vm.MemoryStartup | Should -BeExactly 1024GB
+      $vm.MemoryStartup | Should -BeExactly 1024MB
     }
 
     It "Creates catlet when only the parent is provided" {

--- a/tests/Catlets.Tests.ps1
+++ b/tests/Catlets.Tests.ps1
@@ -25,9 +25,9 @@ name: catlet
       $vm = Get-VM -Name $catletName
 
       $vm.DynamicMemoryEnabled | Should -BeTrue
-      $vm.MemoryStartup | Should -BeExactly (1024 * 1024 * 1024)
-      $vm.MemoryMinimum | Should -BeExactly (512 * 1024 * 1024)
-      $vm.MemoryMaximum | Should -BeExactly (1 * 1024 * 1024 * 1024 * 1024)
+      $vm.MemoryStartup | Should -BeExactly 1024MB
+      $vm.MemoryMinimum | Should -BeExactly 512MB
+      $vm.MemoryMaximum | Should -BeExactly 1TB
     }
 
     It "Creates properly configured catlet without parent" {
@@ -55,14 +55,14 @@ network_adapters:
       $vm.ProcessorCount | Should -BeExactly 3
 
       $vm.DynamicMemoryEnabled | Should -BeTrue
-      $vm.MemoryStartup | Should -BeExactly (1024 * 1024 * 1024)
-      $vm.MemoryMinimum | Should -BeExactly (256 * 1024 * 1024)
-      $vm.MemoryMaximum | Should -BeExactly (2048 * 1024 * 1024)
+      $vm.MemoryStartup | Should -BeExactly 1024MB
+      $vm.MemoryMinimum | Should -BeExactly 256MB
+      $vm.MemoryMaximum | Should -BeExactly 2048MB
 
       $vm.HardDrives | Should -HaveCount 1
       $vm.HardDrives[0].Path | Should -BeLike "*\p_$($project.Name)\*\sda.vhdx"
       $vhd = Get-VHD -Path $vm.HardDrives[0].Path
-      $vhd.Size | Should -BeExactly (50 * 1024 * 1024 * 1024)
+      $vhd.Size | Should -BeExactly 50GB
 
       $vm.NetworkAdapters | Should -HaveCount 1
       $vm.NetworkAdapters[0].Name | Should -BeExactly 'public'
@@ -83,7 +83,7 @@ capabilities:
       $vm = Get-VM -Name $catletName
 
       $vm.DynamicMemoryEnabled | Should -BeFalse
-      $vm.MemoryStartup | Should -BeExactly (1024 * 1024 * 1024)
+      $vm.MemoryStartup | Should -BeExactly 1024GB
     }
 
     It "Creates catlet when only the parent is provided" {
@@ -300,7 +300,7 @@ fodder:
     }
   }
 
-  Describe "Update-Catlet" {
+  Context "Update-Catlet" {
     # When updating a catlet, the name and project must be specified
     # in the config. Otherwise, eryph assumes the default values and
     # moves and renames the catlet.
@@ -354,7 +354,34 @@ fodder:
       Update-Catlet -Id $catlet.Id -Config $updateConfig
 
       $vm = Get-VM -Name $catletName
-      $vm.MemoryStartup | Should -BeExactly (2048 * 1024 * 1024)
+      $vm.MemoryStartup | Should -BeExactly 2048MB
+    }
+  }
+
+  Context "Inventory" {
+    It "Updates inventory when catlet is changed in Hyper-V" {
+      $config = @"
+name: $catletName
+project: $($project.Name)
+parent: dbosoft/e2etests-os/base
+cpu:
+  count: 1
+memory:
+  startup: 1024
+"@
+      $catlet = New-Catlet -Config $config
+
+      $vm = Get-Vm -Name $catletName
+      $vm.ProcessorCount | Should -BeExactly 1
+      $vm.MemoryStartup | Should -BeExactly 1024MB
+
+      Set-VM -Name $catletName -ProcessorCount 3 -MemoryStartupBytes 2048MB
+
+      Wait-Assert {
+        $catletConfig = Get-Catlet -Id $catlet.Id -Config
+        $catletConfig | Should -Match 'cpu:\s+count: 3'
+        $catletConfig | Should -Match 'memory:\s+startup: 2048'
+      }
     }
   }
 

--- a/tests/Helpers.ps1
+++ b/tests/Helpers.ps1
@@ -106,6 +106,39 @@ function Connect-CatletIp {
   return $sshSession
 }
 
+function Wait-Assert {
+  param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [scriptblock]
+    $Assertion,
+
+    [Parameter()]
+    [timespan]
+    $Timeout = (New-TimeSpan -Minutes 1),
+
+    [Parameter()]
+    [timespan]
+    $Interval = (New-TimeSpan -Seconds 5)
+  )
+
+  $PSNativeCommandUseErrorActionPreference = $true
+  $ErrorActionPreference = 'Stop'
+
+  $cutOff = (Get-Date).Add($Timeout)
+
+  while ($true) {
+    try {
+      & $Assertion
+      return
+    } catch {
+      if ((Get-Date) -gt $cutOff) {
+        throw
+      }
+    }
+    Start-Sleep -Seconds $Interval.TotalSeconds
+  }
+}
+
 function New-TestProject {
   $projectName = "test-$(Get-Date -Format 'yyyyMMddHHmmss')"
   New-EryphProject -Name $projectName

--- a/tests/NetworkProviders.Tests.ps1
+++ b/tests/NetworkProviders.Tests.ps1
@@ -222,11 +222,12 @@ networks:
       $catletIps | Should -HaveCount 1
       ([System.Net.IPNetwork]'10.249.254.0/24').Contains($catletIps[0].IpAddress) | Should -BeTrue
 
-      $internalCatletIps = Get-CatletIp -Id $catlet.Id -Internal
-      $internalCatletIps | Assert-Any { $_.IpAddress -eq '10.0.101.12' }
-      # Currently, the inventory does not update the reported IP addresses
-      # quickly. Hence, we cannot assert the IP address of the flat network.
-      # TODO Update this test after implementing https://github.com/eryph-org/eryph/issues/210
+      Wait-Assert {
+        $internalCatletIps = Get-CatletIp -Id $catlet.Id -Internal
+        $internalCatletIps | Should -HaveCount 2
+        $internalCatletIps | Assert-Any { $_.IpAddress -eq '10.0.101.12' }
+        $internalCatletIps | Assert-Any { $_.IpAddress -eq '172.22.42.43' }
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds some tests for the inventory of catlets. The tests verify that changes which have been made outside of eryph are picked up by the inventory in a timely manner.