### PR TITLE
Improve networking test

### DIFF
--- a/tests/Catlets.Tests.ps1
+++ b/tests/Catlets.Tests.ps1
@@ -675,7 +675,7 @@ networks:
 
       # We cannot connect via SSH to the second IP address as the NAT is
       # broken for the second network. Linux uses the weak host model for
-      # IP which means that a response is not necessary
+      # IP which means that a response is not necessarily
       # sent on the same interface as the request was received.
       # At some point, this test should use multiple network providers.
     }


### PR DESCRIPTION
This PR improves a networking test by changing the invocation of `dhcpcd` and validating result more thoroughly.