### PR TITLE
Test update of catlet with checkpoint

### DIFF
--- a/tests/Catlets.Tests.ps1
+++ b/tests/Catlets.Tests.ps1
@@ -495,7 +495,7 @@ drives:
       $vm.ProcessorCount | Should -BeExactly 3
       $vm.HardDrives | Should -HaveCount 1
       $vhd = Get-VHD -Path $vm.HardDrives[0].Path
-      # Disk size should not change as the disk are skipped when a snapshot exists
+      # Disk size should not change as the disks are skipped when a checkpoint exists
       $vhd.Size | Should -BeExactly 100GB
     }
   }

--- a/tests/Catlets.Tests.ps1
+++ b/tests/Catlets.Tests.ps1
@@ -464,7 +464,7 @@ project: $($project.Name)
       $vmProcessor.ExposeVirtualizationExtensions | Should -BeFalse
     }
 
-    It "Updates catlet with snapshot but does not change disks" {
+    It "Updates catlet with checkpoint but does not change disks" {
       $config = @"
 name: $catletName
 project: $($project.Name)


### PR DESCRIPTION
This PR adds a test which verifies that a catlet can be updated when the user has created a snapshot/checkpoint in Hyper-V.