### PR TITLE
Verify that the OVS bridges are removed during uninstallation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ You can run the tests locally as follows:
 4. Open this repository in VS Code as administrator
 5. Make sure the Pester extension is installed. Visual Studio should prompt you.
 6. Run the desired test(s) in the VS Code test explorer
+
+## Notes
+- Powershell strict mode `Set-StrictMode` is not used as it is not supported
+  by Pester v5. Both the `Assert` module and Pester's builtin assertions will
+  e.g. access missing properties without checks or error handling.

--- a/Run-Tests.ps1
+++ b/Run-Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.4
 
-Set-StrictMode -Version 3.0
 $PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 

--- a/Test-Uninstaller.ps1
+++ b/Test-Uninstaller.ps1
@@ -54,6 +54,11 @@ $service | Should -HaveCount 0
 $driver = Get-WindowsDriver -Online | Where-Object { $_.OriginalFileName -ilike "*dbo_ovse*" }
 $driver | Should -HaveCount 0
 
+# Verify that the OVS bridges have been removed
+$networkAdapters = Get-NetAdapter -IncludeHidden
+$networkAdapters | Assert-All { $_.Name -ine "br-nat" }
+$networkAdapters | Assert-All { $_.Name -ine "br-int" }
+
 $rootCertificates = Get-Item Cert:\LocalMachine\Root\* | Where-Object { $_.Issuer -ilike "*eryph*" }
 $rootCertificates | Should -HaveCount 0
 $myCertificates = Get-Item Cert:\LocalMachine\My\* | Where-Object { $_.Issuer -ilike "*eryph*" }

--- a/Test-Uninstaller.ps1
+++ b/Test-Uninstaller.ps1
@@ -5,7 +5,6 @@
 #Requires -Module Pester
 #Requires -Module Assert
 
-Set-StrictMode -Version 3.0
 $PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 

--- a/Test-Uninstaller.ps1
+++ b/Test-Uninstaller.ps1
@@ -55,13 +55,13 @@ $driver | Should -HaveCount 0
 
 # Verify that the OVS bridges have been removed
 $networkAdapters = Get-NetAdapter -IncludeHidden
-$networkAdapters | Assert-All { $_.Name -ine "br-nat" }
-$networkAdapters | Assert-All { $_.Name -ine "br-int" }
+$null = $networkAdapters | Assert-All { $_.Name -ine "br-nat" }
+$null = $networkAdapters | Assert-All { $_.Name -ine "br-int" } 
 
 $rootCertificates = Get-Item Cert:\LocalMachine\Root\* | Where-Object { $_.Issuer -ilike "*eryph*" }
 $rootCertificates | Should -HaveCount 0
 $myCertificates = Get-Item Cert:\LocalMachine\My\* | Where-Object { $_.Issuer -ilike "*eryph*" }
 $myCertificates | Should -HaveCount 0
 
-Get-VM | Assert-All { $_.Name -ne $catletName }
+$null = Get-VM | Assert-All { $_.Name -ne $catletName }
 $disk.Path | Should -Not -Exist

--- a/Use-Settings.ps1
+++ b/Use-Settings.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.4
 
-Set-StrictMode -Version 3.0
 $PSNativeCommandUseErrorActionPreference = $true
 $ErrorActionPreference = 'Stop'
 

--- a/tests/Helpers.ps1
+++ b/tests/Helpers.ps1
@@ -20,7 +20,6 @@ function Connect-Catlet {
     $WaitForCloudInit
   )
 
-  Set-StrictMode -Version 3.0
   $PSNativeCommandUseErrorActionPreference = $true
   $ErrorActionPreference = 'Stop'
 
@@ -53,7 +52,6 @@ function Connect-CatletIp {
     $WaitForCloudInit
   )
 
-  Set-StrictMode -Version 3.0
   $PSNativeCommandUseErrorActionPreference = $true
   $ErrorActionPreference = 'Stop'
   
@@ -128,7 +126,6 @@ function Wait-Assert {
     $Interval = (New-TimeSpan -Seconds 5)
   )
 
-  Set-StrictMode -Version 3.0
   $PSNativeCommandUseErrorActionPreference = $true
   $ErrorActionPreference = 'Stop'
 
@@ -163,7 +160,6 @@ function Setup-Gene {
     $GeneSetTag
   )
 
-  Set-StrictMode -Version 3.0
   $PSNativeCommandUseErrorActionPreference = $true
   $ErrorActionPreference = 'Stop'
 
@@ -197,7 +193,6 @@ function Setup-Gene {
 
 function Setup-GenePool {
 
-  Set-StrictMode -Version 3.0
   $PSNativeCommandUseErrorActionPreference = $true
   $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
This PR adds additional verification to the uninstaller test which ensures that the OVS bridges are removed during uninstallation.