### PR TITLE
Fix identity client usage

### DIFF
--- a/tests/Identity.Tests.ps1
+++ b/tests/Identity.Tests.ps1
@@ -56,7 +56,7 @@ Describe "Identity" {
   }
 
   AfterEach {
-    Remove-EryphClient -Id $client.Id
+    Remove-EryphClient -Id $client.Id -Force
     Remove-EryphProject -Id $project.Id -Force
   }
 }

--- a/tests/ProjectMembers.Tests.ps1
+++ b/tests/ProjectMembers.Tests.ps1
@@ -32,7 +32,7 @@ Describe "ProjectMembers" {
   }
 
   AfterEach {
-    Remove-EryphClient -Id $client.Id
+    Remove-EryphClient -Id $client.Id -Force
     Remove-EryphProject -Id $project.Id -Force
   }
 }


### PR DESCRIPTION
This PR fixes the usage of the identity client. The cmdlet `Remove-EryphClient` now requires the `-Force` parameter.